### PR TITLE
fix(EventHandling): Support for IE8 key events

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -8,7 +8,7 @@
 
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.23/angular.min.js"></script>
-    <script src="angular-payment-tpls-0.3.0.js"></script>
+    <script src="angular-payment-tpls-0.4.0-SNAPSHOT.js"></script>
     <script src="assets/app.js"></script>
     <script src="assets/dropdownToggle.js"></script>
 
@@ -59,7 +59,7 @@
             <a class="btn btn-default" href="https://github.com/seandesmond/angular-payment"><i class="icon-github"></i> Code on Github</a>
             <a class="btn btn-primary" href="https://github.com/seandesmond/angular-payment/tree/gh-pages">
                 <i class="icon-download-alt icon-white"></i> Download
-                <small>(0.3.0)</small>
+                <small>(0.4.0-SNAPSHOT)</small>
             </a>
         </div>
     </div>

--- a/src/cardCvc/cardCvc.js
+++ b/src/cardCvc/cardCvc.js
@@ -12,8 +12,8 @@ angular.module('payment.cardCvc', ['payment.service', 'payment.restrictNumeric']
     .directive('cardCvcFormatter', function () {
         'use strict';
         var restrictCvc = function (e) {
-            var elm = angular.element(e.currentTarget), digit, val;
-            digit = String.fromCharCode(e.which);
+            var elm = angular.element(e.currentTarget || e.srcElement), digit, val;
+            digit = String.fromCharCode(e.which || e.keyCode);
             if (!/^\d+$/.test(digit)) { return; }
 
             val = elm.val() + digit;

--- a/src/cardExpiry/cardExpiry.js
+++ b/src/cardExpiry/cardExpiry.js
@@ -14,9 +14,9 @@ angular.module('payment.cardExpiry', ['payment.service', 'payment.restrictNumeri
         var formatExpiry = function (e) {
                 var elm, digit, val;
 
-                digit = String.fromCharCode(e.which);
+                digit = String.fromCharCode(e.which  || e.keyCode);
                 if (!/^\d+$/.test(digit)) { return; }
-                elm = angular.element(e.currentTarget);
+                elm = angular.element(e.currentTarget || e.srcElement);
                 val = elm.val() + digit;
                 if (/^\d$/.test(val) && (val !== '0' && val !== '1')) {
                     e.preventDefault();
@@ -29,18 +29,18 @@ angular.module('payment.cardExpiry', ['payment.service', 'payment.restrictNumeri
             formatForwardExpiry = function (e) {
                 var elm, digit, val;
 
-                digit = String.fromCharCode(e.which);
+                digit = String.fromCharCode(e.which  || e.keyCode);
                 if (!/^\d+$/.test(digit)) { return; }
-                elm = angular.element(e.currentTarget);
+                elm = angular.element(e.currentTarget || e.srcElement);
                 val = elm.val();
                 if (/^\d\d$/.test(val)) { elm.val(val + ' / '); }
             },
             formatForwardSlash = function (e) {
                 var elm, slash, val;
 
-                slash = String.fromCharCode(e.which);
+                slash = String.fromCharCode(e.which  || e.keyCode);
                 if (slash !== '/') { return; }
-                elm = angular.element(e.currentTarget);
+                elm = angular.element(e.currentTarget || e.srcElement);
                 val = elm.val();
                 if (/^\d$/.test(val) && val !== '0') { elm.val(val + " / "); }
             },
@@ -48,9 +48,9 @@ angular.module('payment.cardExpiry', ['payment.service', 'payment.restrictNumeri
                 var elm, value;
 
                 if (e.meta) { return; }
-                elm = angular.element(e.currentTarget);
+                elm = angular.element(e.currentTarget || e.srcElement);
                 value = elm.val();
-                if (e.which !== 8) { return; }
+                if ((e.which  || e.keyCode) !== 8) { return; }
                 if ((elm.prop('selectionStart') != null) && elm.prop('selectionStart') !== value.length) { return; }
                 if (/\d(\s|\/)+$/.test(value)) {
                     e.preventDefault();
@@ -61,9 +61,9 @@ angular.module('payment.cardExpiry', ['payment.service', 'payment.restrictNumeri
                 }
             },
             restrictExpiry = function (e) {
-                var elm = angular.element(e.currentTarget), digit, value;
+                var elm = angular.element(e.currentTarget || e.srcElement), digit, value;
 
-                digit = String.fromCharCode(e.which);
+                digit = String.fromCharCode(e.which  || e.keyCode);
                 if (!/^\d+$/.test(digit)) { return; }
                 if (payment.hasTextSelected(elm)) { return; }
                 value = elm.val() + digit;

--- a/src/cardNumber/cardNumber.js
+++ b/src/cardNumber/cardNumber.js
@@ -11,7 +11,7 @@ angular.module('payment.cardNumber', ['payment.service', 'payment.restrictNumeri
     .directive('cardNumberFormatter', ['$timeout', '$parse', 'payment', function ($timeout, $parse, payment) {
         'use strict';
         var restrictCardNumber = function (e) {
-                var card, digit = String.fromCharCode(e.which), value, elm = angular.element(e.currentTarget);
+                var card, digit = String.fromCharCode(e.which || e.keyCode), value, elm = angular.element(e.currentTarget || e.srcElement);
 
                 if (!/^\d+$/.test(digit)) { return; }
                 if (payment.hasTextSelected(elm)) { return; }
@@ -28,10 +28,10 @@ angular.module('payment.cardNumber', ['payment.service', 'payment.restrictNumeri
             formatCardNumber = function (e) {
                 var elm, card, digit, length, re, upperLength = 16, value;
 
-                digit = String.fromCharCode(e.which);
+                digit = String.fromCharCode(e.which || e.keyCode);
                 if (!/^\d+$/.test(digit)) { return; }
 
-                elm = angular.element(e.currentTarget);
+                elm = angular.element(e.currentTarget || e.srcElement);
                 value = elm.val();
                 card = payment.cardFromNumber(value + digit);
                 length = (value.replace(/\D/g, '') + digit).length;
@@ -54,7 +54,7 @@ angular.module('payment.cardNumber', ['payment.service', 'payment.restrictNumeri
                 }
             },
             reFormatCardNumber = function (e) {
-                var elm = angular.element(e.currentTarget);
+                var elm = angular.element(e.currentTarget || e.srcElement);
                 $timeout(function () {
                     var value = elm.val();
                     value = payment.formatCardNumber(value);

--- a/src/restrictNumeric/restrictNumeric.js
+++ b/src/restrictNumeric/restrictNumeric.js
@@ -1,10 +1,13 @@
 angular.module('payment.restrictNumeric', [])
-    .directive('restrictNumeric', function () {
+    .directive('restrictNumeric', function() {
         'use strict';
-        var restrictNumeric = function (e) {
-                if (e.metaKey || e.ctrlKey || e.which === 0 || e.which < 33) { return; }
-                if (e.which === 32 || !!/[\d\s]/.test(String.fromCharCode(e.which)) === false) { e.preventDefault(); } // jshint ignore:line
-            };
+        var restrictNumeric = function(e) {
+            if(!e.which){
+                e.which = e.keyCode;
+            }
+            if (e.metaKey || e.ctrlKey || e.which === 0 || e.which < 33) {return;}
+            if (e.which === 32 || !!/[\d\s]/.test(String.fromCharCode(e.which)) === false) {e.preventDefault();} // jshint ignore:line
+        };
 
         return {
             restrict: 'A',


### PR DESCRIPTION
If you're not using the full jQuery library (only using jqLite as part of AngularJS), the directives won't work in IE8. The event objects do not contain

    e.which
or

    e.currentTarget
So we must have the fallback methods implemented like so:

    e.which || e.keyCode
    e.currentTarget || e.srcElement